### PR TITLE
Add the deletion of all transients

### DIFF
--- a/tests/test-delete-all-transients.php
+++ b/tests/test-delete-all-transients.php
@@ -1,0 +1,28 @@
+<?php
+/**
+ * Class DeleteAllTransientsTest
+ *
+ * @package WooCommerce_Reset
+ */
+
+namespace Automattic\WooCommerce\Reset;
+
+/**
+ * Test case for delete_options.
+ */
+class DeleteAllTransientsTest extends \WP_UnitTestCase {
+
+	/**
+	 * Test deleting all transients.
+	 */
+	public function test_delete_all_transients() {
+		set_transient( 'foo', 'foo testing', 60 );
+		set_transient( 'bar', 'bar testing', 60 );
+
+		delete_all_transients();
+
+		$this->assertFalse( get_transient( 'foo' ) );
+		$this->assertFalse( get_transient( 'bar' ) );
+	}
+
+}

--- a/tests/test-rest.php
+++ b/tests/test-rest.php
@@ -50,4 +50,28 @@ class RestTest extends \WP_UnitTestCase {
 		$this->assertFalse( get_option( 'wc_remote_inbox_notifications_wca_updated' ) );
 		$this->assertFalse( get_option( 'woocommerce_admin_install_timestamp' ) );
 	}
+
+	/**
+	 * Test the reset endpoint deletes common woocommerce transients.
+	 */
+	public function test_reset_endpoint_deletes_woocommerce_transients() {
+		global $wp_rest_server;
+
+		$routes = $wp_rest_server->get_routes();
+
+		wp_set_current_user( 0 );
+
+		$request = new \WP_REST_Request( 'DELETE', '/woocommerce-reset/v1/state' );
+
+		$response = $wp_rest_server->dispatch( $request );
+
+		$this->assertEquals( 200, $response->get_status() );
+
+		$this->assertFalse( get_transient( 'wc_products_onsale' ) );
+		$this->assertFalse( get_transient( 'wc_featured_products' ) );
+		$this->assertFalse( get_transient( 'wc_outofstock_count' ) );
+		$this->assertFalse( get_transient( 'wc_low_stock_count' ) );
+		$this->assertFalse( get_transient( 'wc_count_comments' ) );
+		$this->assertFalse( get_transient( 'woocommerce_admin_remote_free_extensions_specs' ) );
+	}
 }

--- a/woocommerce-reset.php
+++ b/woocommerce-reset.php
@@ -56,6 +56,7 @@ function handle_delete_state_route() {
 	 * default value to be assigned when the option is next retrieved by the site.
 	 */
 	delete_options( ...WOOCOMMERCE_OPTIONS );
+	delete_all_transients();
 }
 
 /**
@@ -65,4 +66,13 @@ function handle_delete_state_route() {
  */
 function delete_options( string ...$option_names ) {
 	array_walk( $option_names, 'delete_option' );
+}
+
+/**
+ * Deletes all transients stored in the database.
+ */
+function delete_all_transients() {
+	global $wpdb;
+	$wpdb->query( "DELETE FROM {$wpdb->options} WHERE option_name LIKE '\_transient\_%' " );
+	wp_cache_flush(); // Manually flush the cache after direct database call.
 }


### PR DESCRIPTION
Adds the deletion of all transients to the `DELETE woocommerce-reset/v1/state` endpoint.

This deletes all transients in the WordPress database. To keep things simple I elected not to limit this to only the transients created by Woo. This is because various plugins uses different prefixes such as `wc`, `woocommerce_admin`, `wcpay`. I'm thinking future maintenance will be easier by just having this delete all transients regardless of their origin.

### Testing Instructions

- Add this plugin to an existing site. A .zip can be downloaded from https://github.com/woocommerce/woocommerce-reset/zipball/transients/

- Call the endpoint. For example  `curl -X "DELETE" "http://localhost:8000/index.php?rest_route=/woocommerce-reset/v1/state"`

- Inspect database options table and see that there are no options named `transient_*`

- Run tests locally:

```
composer install
npm install
npm run test
```
