### PR TITLE
Trigger action scheduler

### DIFF
--- a/woocommerce-reset.php
+++ b/woocommerce-reset.php
@@ -44,6 +44,14 @@ add_action(
 				'permission_callback' => '__return_true',
 			)
 		);
+		register_rest_route(
+			'woocommerce-reset/v1',
+			'cron/run',
+			array(
+				'callback' => __NAMESPACE__ . '\\run_cron',
+				'methods'  => 'POST',
+			)
+		);
 	}
 );
 
@@ -75,4 +83,8 @@ function delete_all_transients() {
 	global $wpdb;
 	$wpdb->query( "DELETE FROM {$wpdb->options} WHERE option_name LIKE '\_transient\_%' " );
 	wp_cache_flush(); // Manually flush the cache after direct database call.
+}
+
+function run_cron() {
+	do_action( 'action_scheduler_run_queue', 'Async Request' );
 }

--- a/woocommerce-reset.php
+++ b/woocommerce-reset.php
@@ -85,6 +85,9 @@ function delete_all_transients() {
 	wp_cache_flush(); // Manually flush the cache after direct database call.
 }
 
+/** 
+ * Runs the action scheduler.
+ */
 function run_cron() {
 	do_action( 'action_scheduler_run_queue', 'Async Request' );
 }


### PR DESCRIPTION
I am not a 100% sure if this belongs in the `woocommerce-reset` plugin, but I am not sure how else to trigger the action scheduler. I am asking Solaris as well.

## Testing Instructions

- Load this branch as a plugin and enable it
- Go to **WooCommerce > Status > Scheduled Actions** and make sure you have some pending items (create a new order if you don't)
- Open your console and run `wp.apiFetch({ method: 'POST', path: '/woocommerce-reset/v1/cron/run'});`
- Refresh the `Scheduled Actions` page, all the pending items should have been run.