### PR TITLE
Add/deactivate and delete plugins

### DIFF
--- a/woocommerce-reset.php
+++ b/woocommerce-reset.php
@@ -90,20 +90,21 @@ function handle_delete_state_route( $request ) {
 	 * default value to be assigned when the option is next retrieved by the site.
 	 */
 	$options              = delete_options( ...WOOCOMMERCE_OPTIONS );
-	$skipped_plugin_slugs =  $request->has_param( 'skipped_plugin_slugs' ) ? $request->get_param( 'skipped_plugin_slugs' ) : array();
-	deactivate_and_delete_plugins( $skipped_plugin_slugs );
-	$transients        = delete_all_transients();
-	$notes             = truncate_note_tables();
-	$general_settings  = reset_settings( 'general' );
-	$products_settings = reset_settings( 'products' );
-	$tax_settings      = reset_settings( 'tax' );
+	$skipped_plugin_slugs = $request->has_param( 'skipped_plugin_slugs' ) ? $request->get_param( 'skipped_plugin_slugs' ) : array();
+	$delete_plugins       = deactivate_and_delete_plugins( $skipped_plugin_slugs );
+	$transients           = delete_all_transients();
+	$notes                = truncate_note_tables();
+	$general_settings     = reset_settings( 'general' );
+	$products_settings    = reset_settings( 'products' );
+	$tax_settings         = reset_settings( 'tax' );
 	run_cron_job_by_hook( 'wc_admin_daily' );
 
 	return array(
-		'options'    => $options,
-		'transients' => $transients,
-		'notes'      => $notes,
-		'settings'   => array(
+		'options'        => $options,
+		'transients'     => $transients,
+		'delete_plugins' => $delete_plugins,
+		'notes'          => $notes,
+		'settings'       => array(
 			'general'  => $general_settings,
 			'products' => $products_settings,
 			'tax'      => $tax_settings,
@@ -291,5 +292,5 @@ function deactivate_and_delete_plugins( $skipped_plugins ) {
 		}
 	}
 	deactivate_plugins( $to_be_deleted );
-	delete_plugins( $to_be_deleted );
+	return delete_plugins( $to_be_deleted );
 }

--- a/woocommerce-reset.php
+++ b/woocommerce-reset.php
@@ -281,6 +281,9 @@ function deactivate_and_delete_plugins( $skipped_plugins ) {
 	if ( ! function_exists( 'get_plugins' ) ) {
 		require_once ABSPATH . 'wp-admin/includes/plugin.php';
 	}
+	if ( ! function_exists( 'request_filesystem_credentials' ) ) {
+		require_once ABSPATH . 'wp-admin/includes/file.php';
+	}
 	$default_skipped = array( 'woocommerce', 'woocommerce-admin', 'woocommerce-reset', 'Basic-Auth' );
 	$skipped_plugins = array_merge( $skipped_plugins, $default_skipped );
 	$installed_plugins = get_installed_plugins();

--- a/woocommerce-reset.php
+++ b/woocommerce-reset.php
@@ -277,6 +277,9 @@ function get_installed_plugins() {
 }
 
 function deactivate_and_delete_plugins( $skipped_plugins ) {
+	if ( ! function_exists( 'get_plugins' ) ) {
+		require_once ABSPATH . 'wp-admin/includes/plugin.php';
+	}
 	$default_skipped = array( 'woocommerce', 'woocommerce-admin', 'woocommerce-reset', 'Basic-Auth' );
 	$skipped_plugins = array_merge( $skipped_plugins, $default_skipped );
 	$installed_plugins = get_installed_plugins();


### PR DESCRIPTION
Adds functionality to deactivate and delete plugins

## Testing instructions
**NOTE: this will delete and deactivate the majority of your plugins**
1. Clone this repo in your plugins folder and checkout this branch
2. Enable the WooCommerce Reset plugin
3. Open **WooCommerce > Home** and open your console
4. Run `wp.apiFetch({ method: 'DELETE', path: '/woocommerce-reset/v1/state'});`
5. Go to **Plugins > Installed plugins** check if all plugins are deleted aside from woocommerce and woocommerce admin and this reset plugin. We are also skipping `Basic-Auth` used in E2E tests.
6. Install a new plugin and run the above request again, this time with the `skipped_plugin_slugs` param with your installed plugin: `wp.apiFetch({ method: 'DELETE', path: '/woocommerce-reset/v1/state', data: { skipped_plugin_slugs: [ 'your_plugin_slug' ] }});`
7. Check the installed plugins and make sure that your installed plugin has been skipped and is still installed.